### PR TITLE
Konfiguration av maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <name>scrabble</name>
 
   <properties>
+    <java.version>1.7</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -27,4 +28,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Lagt till konfiguration av modul maven-compiler-plugin. Först och främst så java 1.7 används vid kompilering men även att det genererar varningar för unchecked conversions.